### PR TITLE
Add documentation for top-level folders

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -1,0 +1,13 @@
+# Collections
+
+This directory houses Postman collections that cover different Aqua product APIs.
+
+## Available collections
+
+- **Aqua Enterprise API.postman_collection.json** – Core Aqua Enterprise platform endpoints, including inventory, runtime policies, and administrative operations that most users integrate with first.
+- **Aqua CSPM API.postman_collection.json** – Cloud Security Posture Management endpoints for assessing cloud resources.
+- **Aqua SSCS API.postman_collection.json** – Software Supply Chain Security endpoints that support scanning images and pipelines.
+
+### Usage tips
+
+Import the required collection into Postman and pair it with the matching environment template from `../environments`. Review the [Aqua Postman Guide](../docs/Aqua%20Postman%20Guide.pdf) for setup steps and workflow examples.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+Reference material that explains how to use the Aqua Postman collections lives in this directory.
+
+## Files
+
+- **Aqua Postman Guide.pdf** – Step-by-step walkthrough for importing the collections, configuring environments, and exercising key Aqua Enterprise, CSPM, and SSCS workflows in Postman.
+
+Check this folder whenever new guides or onboarding resources are added to the repository.

--- a/environments/README.md
+++ b/environments/README.md
@@ -1,0 +1,13 @@
+# Environments
+
+Reusable Postman environment templates that complement the Aqua API collections are stored here.
+
+## Available environments
+
+- **aqua.postman_environment.json** – Variables for the Aqua Enterprise API, including console URL, credentials, and token placeholders.
+- **cspm.postman_environment.json** – Cloud Security Posture Management–specific variables.
+- **sscs.postman_environment.json** – Configuration for interacting with Software Supply Chain Security endpoints.
+
+### Getting started
+
+Duplicate the environment that matches your deployment, populate the secrets with your tenant-specific values, and select it in Postman before calling the associated collection.

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,5 @@
+# Images
+
+Screenshots and artwork that support the Aqua API documentation live in this directory. They are referenced by the root `README.md` and the PDF guides inside `../docs` to illustrate setup steps.
+
+When adding new walkthroughs or updating UI captures, store the image assets here so that other contributors can keep the documentation consistent.


### PR DESCRIPTION
## Summary
- add README files to each top-level directory so contributors can quickly understand available assets
- highlight the Aqua Enterprise collection alongside other Postman collections and environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd31cabbbc83289b48d6d9aad4ee7a